### PR TITLE
Update example to new helm provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,12 @@
 Here's the gist of using it via github.
 
 ```terraform
-data helm_repository stable {
-  name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
-}
-
 module jenkins {
   source  = "terraform-module/release/helm"
   version = "2.6.0"
 
   namespace  = "app-namespace"
-  repository =  data.helm_repository.stable.metadata[0].name
+  repository =  "https://charts.helm.sh/stable"
 
   app = {
     name          = "jenkins"


### PR DESCRIPTION
- Data resource for repositories is deprecated
- Updated URL to new stable repository location (see https://helm.sh/blog/new-location-stable-incubator-charts/)